### PR TITLE
Feat/menu

### DIFF
--- a/media/gallery.js
+++ b/media/gallery.js
@@ -27,7 +27,7 @@
 		if (!node.classList.contains('image')) { return; }
 
 		vscode.postMessage({
-			command: 'vscodeImageGallery.openImageViewer',
+			command: 'vscodeImageGallery.openViewer',
 			src: node.src,
 		});
 		console.log('User clicked on: ' + node.src);

--- a/media/gallery.js
+++ b/media/gallery.js
@@ -27,7 +27,7 @@
 		if (!node.classList.contains('image')) { return; }
 
 		vscode.postMessage({
-			command: 'vscode-image-gallery.openImageViewer',
+			command: 'vscodeImageGallery.openImageViewer',
 			src: node.src,
 		});
 		console.log('User clicked on: ' + node.src);

--- a/package.json
+++ b/package.json
@@ -16,16 +16,25 @@
 		"Visualization"
 	],
 	"activationEvents": [
-		"onCommand:vscode-image-gallery.start"
+		"onCommand:vscodeImageGallery.openGallery"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
 		"commands": [
 			{
-				"command": "vscode-image-gallery.start",
-				"title": "Image Gallery: Open Image Gallery"
+				"command": "vscodeImageGallery.openGallery",
+				"title": "Open Image Gallery"
 			}
-		]
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "vscodeImageGallery.openGallery",
+					"group": "3_imageGallery",
+					"when": "explorerResourceIsFolder"
+				}
+			]
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
 			mainPanel.webview.onDidReceiveMessage(
 				message => {
 					switch (message.command) {
-						case 'vscodeImageGallery.openImageViewer':
+						case 'vscodeImageGallery.openViewer':
 							viewer_panel.createPanel(context, mainPanel.webview, message.src);
 							return;
 					}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,23 +3,26 @@ import * as main_panel from './main_panel';
 import * as viewer_panel from './viewer_panel';
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log('Congratulations, extension "vscode-image-gallery" is now active!');
+	console.log('Congratulations, extension "VS Code Image Gallery" is now active!');
 
-	let disposable = vscode.commands.registerCommand('vscode-image-gallery.start', async () => {
-		const mainPanel = await main_panel.createPanel(context);
-		
-		mainPanel.webview.onDidReceiveMessage(
-			message => {
-				switch (message.command) {
-					case 'vscode-image-gallery.openImageViewer':
-						viewer_panel.createPanel(context, mainPanel.webview, message.src);
-						return;
-				}
-			},
-			undefined,
-			context.subscriptions,
-		);
-	});
+	let disposable = vscode.commands.registerCommand(
+		'vscodeImageGallery.openGallery',
+		async (galleryFolder?: vscode.Uri) => {
+			const mainPanel = await main_panel.createPanel(context, galleryFolder);
+			
+			mainPanel.webview.onDidReceiveMessage(
+				message => {
+					switch (message.command) {
+						case 'vscodeImageGallery.openImageViewer':
+							viewer_panel.createPanel(context, mainPanel.webview, message.src);
+							return;
+					}
+				},
+				undefined,
+				context.subscriptions,
+			);
+		}
+	);
 
 	context.subscriptions.push(disposable);
 }

--- a/src/main_panel.ts
+++ b/src/main_panel.ts
@@ -2,15 +2,14 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as utils from './utils';
 
-export async function createPanel(context: vscode.ExtensionContext) {
+export async function createPanel(context: vscode.ExtensionContext, galleryFolder?: vscode.Uri) {
     const panel = vscode.window.createWebviewPanel(
-        'imagegallery',
+        'imageGallery',
         'Image Gallery',
         vscode.ViewColumn.One,
         {
             localResourceRoots: [
-                vscode.Uri.file(
-                    utils.getCwd()),
+                vscode.Uri.file(utils.getCwd()),
                 vscode.Uri.file(path.join(context.extensionPath, 'media'),
                 ),
             ],
@@ -18,7 +17,9 @@ export async function createPanel(context: vscode.ExtensionContext) {
         }
     );
 
-    const imgPaths = await getImagePaths();
+    const imgPaths = await getImagePaths(
+        galleryFolder ? vscode.workspace.asRelativePath(galleryFolder, false) : undefined
+    );
     const imgWebviewUris = imgPaths.map(
         imgPath => panel.webview.asWebviewUri(imgPath)
     );
@@ -27,7 +28,7 @@ export async function createPanel(context: vscode.ExtensionContext) {
     return panel;
 }
 
-export async function getImagePaths() {
+export async function getImagePaths(galleryFolder?: string) {
     const imgExtensions = [
         'jpg',
         'JPG',
@@ -40,7 +41,10 @@ export async function getImagePaths() {
         'webp',
         'WEBP',
     ];
-    const files = await vscode.workspace.findFiles('**/*.{' + imgExtensions.join(',') + '}');
+    const globPattern = '**/*.{' + imgExtensions.join(',') + '}';
+    const files = await vscode.workspace.findFiles(
+        galleryFolder ? galleryFolder + globPattern : globPattern
+    );
     const imgPaths = files.map(
         file => vscode.Uri.file(file.fsPath)
     );

--- a/src/viewer_panel.ts
+++ b/src/viewer_panel.ts
@@ -8,7 +8,7 @@ export function createPanel(
 	imgSrc: string,
 ) {
 	const panel = vscode.window.createWebviewPanel(
-		'imagegallery',
+		'imageGallery',
 		'Image Gallery: Viewer',
 		vscode.ViewColumn.Two,
 		{


### PR DESCRIPTION
<img width="357" alt="image" src="https://user-images.githubusercontent.com/21100851/162646204-7221950c-17d1-4c0a-81e7-1ee20aefb1ac.png">

Right click to open Gallery for the selected folder rather than the entire workspace folder.

Of course, a lot more fine tunings can be done. But for now this should resolve #20, in which the extension becomes totally unusable for big project.

**I was trying to implement the Viewer (by right click) too, but it turns out to be more difficult than I thought. So let's keep that for another issue.