### PR TITLE
:children_crossing: Zoom at center

### DIFF
--- a/media/viewer.js
+++ b/media/viewer.js
@@ -2,9 +2,6 @@
 	const container = document.getElementById('container');
 
 	panzoom(container, {
-		minZoom: 0.4,
-		bounds: true,
-		boundsPadding: 0.1,
-		transformOrigin: { x: 0.5, y: 0.5 }
+		minZoom: 0.6,
 	});
 }());


### PR DESCRIPTION
This should resolve #17.

It turns out that the default panzoom behavior is already what I wanted.